### PR TITLE
add runCI job

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -23,3 +23,11 @@ jobs:
       - TASK: managed
 
 # / TEST deployment for VISUALIZER to Amazon ECS
+
+# Connect CI with dv-img resource
+#  - name: samplePipelinesDemo_runCI
+#    type: runCI
+#    steps:
+#      - OUT: dv-img
+# / Connect CI with dv-img resource
+


### PR DESCRIPTION
adding a commented runCI job, for use with the shippable intro to pipelines tutorial.